### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=5.6",
-        "magento/module-catalog": "^100|^101|^102",
+        "magento/module-catalog": "^100|^101|^102|^103",
         "snowio/magento2-lock": "^1.1.0",
-        "magento/framework": "^100|^101"
+        "magento/framework": "^100|^101|^102"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. No additional modifications were needed

**NB**: This is dependant on https://github.com/snowio/magento2-lock/pull/7